### PR TITLE
Use flytekit that supports separate console endpoint config

### DIFF
--- a/ci/build/build-vscode.sh
+++ b/ci/build/build-vscode.sh
@@ -81,7 +81,8 @@ main() {
     "tipsAndTricksUrl": "https://go.microsoft.com/fwlink/?linkid=852118",
     "newsletterSignupUrl": "https://www.research.net/r/vsc-newsletter",
     "linkProtectionTrustedDomains": [
-      "https://open-vsx.org"
+      "https://open-vsx.org",
+      "https://*.union.ai"
     ],
     "aiConfig": {
       "ariaKey": "code-server"

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update \
   sudo \
   vim.tiny \
   lsb-release \
-  jq \
   && git lfs install \
   && rm -rf /var/lib/apt/lists/*
 

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # flytekit
-RUN pip install flytekit
+RUN pip install git+https://github.com/flyteorg/flytekit.git@b1dbab951e4d5562facf913e77b6d64c0da527e4#egg=flytekit
 
 # flytectl
 RUN curl -sL https://ctl.flyte.org/install | bash

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   sudo \
   vim.tiny \
   lsb-release \
+  jq \
   && git lfs install \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Pickup flytekit (and flytectl automatically via :latest) that can read separate console endpoint added in https://github.com/flyteorg/flytectl/pull/361

Add union.ai to the trusted domains so that navigating to sandbox.union.ai doesn't pop a trust warning