### PR TITLE
Install flyte extension

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -159,7 +159,7 @@ jobs:
         uses: robinraju/release-downloader@v1.5
         with:
           repository: "unionai/vscode-extensions"
-          tag: flyte-sandbox-0.0.9
+          tag: flyte-sandbox-0.0.10
           fileName: "flyte-sandbox*.vsix"
           out-file-path: "release-packages"
           token: ${{ secrets.CI_BOT_PAT }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -159,7 +159,7 @@ jobs:
         uses: robinraju/release-downloader@v1.5
         with:
           repository: "unionai/vscode-extensions"
-          tag: flyte-sandbox-0.0.8
+          tag: flyte-sandbox-0.0.9
           fileName: "flyte-sandbox*.vsix"
           out-file-path: "release-packages"
           token: ${{ secrets.CI_BOT_PAT }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -159,8 +159,8 @@ jobs:
         uses: robinraju/release-downloader@v1.5
         with:
           repository: "unionai/vscode-extensions"
-          tag: flyte-sandbox-v0.0.8
-          fileName: "flyte-sandbox-v0.0.8.vsix"
+          tag: flyte-sandbox-0.0.8
+          fileName: "flyte-sandbox*.vsix"
           out-file-path: "release-packages"
           token: ${{ secrets.CI_BOT_PAT }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -155,6 +155,15 @@ jobs:
           fileName: "*.deb"
           out-file-path: "release-packages"
 
+      - name: Download Flyte vscode extension
+        uses: robinraju/release-downloader@v1.5
+        with:
+          repository: "unionai/vscode-extensions"
+          tag: flyte-sandbox-v0.0.8
+          fileName: "flyte-sandbox-v0.0.8.vsix"
+          out-file-path: "release-packages"
+          token: ${{ secrets.CI_BOT_PAT }}
+
       - name: Publish to Docker
         run: yarn publish:docker
         env:

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -32,10 +32,6 @@ RUN pip install git+https://github.com/flyteorg/flytekit.git@b1dbab951e4d5562fac
 # flytectl
 RUN curl -sL https://ctl.flyte.org/install | bash
 
-# vscode extensions
-RUN code-server --install-extension ms-python.python
-RUN --mount=from=packages,src=/tmp,dst=/tmp/packages ls /tmp/packages/flyte-sandbox*.vsix | head -1 | xargs -I {} sh -c "code-server --install-extension {}"
-
 # https://wiki.debian.org/Locale#Manually
 RUN sed -i "s/# en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen \
   && locale-gen
@@ -64,6 +60,10 @@ EXPOSE 8080
 # docker-run.
 USER 1000
 ENV USER=coder
+
+# vscode extensions
+RUN code-server --install-extension ms-python.python
+RUN --mount=from=packages,src=/tmp,dst=/tmp/packages ls /tmp/packages/flyte-sandbox*.vsix | head -1 | xargs -I {} sh -c "code-server --install-extension {}"
 
 RUN mkdir -p /home/coder/flyte
 WORKDIR /home/coder/flyte

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM scratch AS packages
 COPY release-packages/code-server*.deb /tmp/
+COPY release-packages/flyte-sandbox*.vsix /tmp/
 
 FROM debian:11
 
@@ -63,5 +64,6 @@ ENV USER=coder
 RUN mkdir -p /home/coder/flyte
 WORKDIR /home/coder/flyte
 RUN git clone https://github.com/flyteorg/flytesnacks
+RUN --mount=from=packages,src=/tmp,dst=/tmp/packages /usr/bin/code-server --install-extension /tmp/packages/flyte-sandbox-v0.0.8.vsix
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "."]

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -64,6 +64,6 @@ ENV USER=coder
 RUN mkdir -p /home/coder/flyte
 WORKDIR /home/coder/flyte
 RUN git clone https://github.com/flyteorg/flytesnacks
-RUN --mount=from=packages,src=/tmp,dst=/tmp/packages /usr/bin/code-server --install-extension /tmp/packages/flyte-sandbox-v0.0.8.vsix
+RUN --mount=from=packages,src=/tmp,dst=/tmp/packages ls /tmp/packages/flyte-sandbox*.vsix | head -1 | xargs -I {} sh -c "code-server --install-extension {}"
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "."]

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -32,6 +32,10 @@ RUN pip install git+https://github.com/flyteorg/flytekit.git@b1dbab951e4d5562fac
 # flytectl
 RUN curl -sL https://ctl.flyte.org/install | bash
 
+# vscode extensions
+RUN code-server --install-extension ms-python.python
+RUN --mount=from=packages,src=/tmp,dst=/tmp/packages ls /tmp/packages/flyte-sandbox*.vsix | head -1 | xargs -I {} sh -c "code-server --install-extension {}"
+
 # https://wiki.debian.org/Locale#Manually
 RUN sed -i "s/# en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen \
   && locale-gen
@@ -64,6 +68,5 @@ ENV USER=coder
 RUN mkdir -p /home/coder/flyte
 WORKDIR /home/coder/flyte
 RUN git clone https://github.com/flyteorg/flytesnacks
-RUN --mount=from=packages,src=/tmp,dst=/tmp/packages ls /tmp/packages/flyte-sandbox*.vsix | head -1 | xargs -I {} sh -c "code-server --install-extension {}"
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "."]


### PR DESCRIPTION
This change preinstalls the flyte vscode extension into the code-server image. The extension is pulled from github.com/unionai/vscode-extensions/releases